### PR TITLE
fix: Update call to SLSA Node.js Builder

### DIFF
--- a/.github/workflows/publish_in_npm.yml
+++ b/.github/workflows/publish_in_npm.yml
@@ -3,25 +3,32 @@ on:
   release:
     types:
       - created
+
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.x]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build on Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
-      - name: Run npm install ci
-        run: npm ci
-  publish:
-    needs: prepare
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@5dfe44f2f2806e28957c9de7aaa1fb9973921187
+  build:
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v1.6.0
     with:
       node-version: 18.16.0
-    secrets:
-      node-auth-token: ${{ secrets.NPM_TOKEN }}
+
+  publish:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node registry authentication
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 18.16.0
+          registry-url: "https://registry.npmjs.org"
+
+      - name: publish
+        id: publish
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@0779f7bec68e2bf54a7b0a32bf4763f25ab29702 # v1.6.0
+        with:
+          access: public
+          node-auth-token: ${{ secrets.NPM_TOKEN }}
+          package-name: ${{ needs.build.outputs.package-name }}
+          package-download-name: ${{ needs.build.outputs.package-download-name }}
+          package-download-sha256: ${{ needs.build.outputs.package-download-sha256 }}
+          provenance-name: ${{ needs.build.outputs.provenance-name }}
+          provenance-download-name: ${{ needs.build.outputs.provenance-download-name }}
+          provenance-download-sha256: ${{ needs.build.outputs.provenance-download-sha256 }}


### PR DESCRIPTION
- Removed the initial "prepare" job as it was unnecessary.
- Reference the builder by tag. See: https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators
- Add call to separate publish action to publish to npm registry.